### PR TITLE
source image was changed from ubuntu to debian:jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM       ubuntu:13.10
+FROM       debian:jessie
 MAINTAINER Nate Jones <nate@endot.org>
 
 RUN echo "deb http://www.rabbitmq.com/debian/ testing main" > /etc/apt/sources.list.d/rabbitmq.list


### PR DESCRIPTION
Using ubuntu image, some repository errors was occurring during image build .

Considering that minimal debian machine is sufficient for this operation, this change follows the official Docker recommendation:
https://docs.docker.com/articles/dockerfile_best-practices/#from
